### PR TITLE
Audit contracts

### DIFF
--- a/libs/coinflip-contracts/src/Wallets.sol
+++ b/libs/coinflip-contracts/src/Wallets.sol
@@ -46,14 +46,14 @@ contract Wallets is UsingReentrancyGuard {
         address oneAccount,
         uint amountForOneAccount
     ) external payable {
-        uint16 manyAccountsLength = uint16(manyAccounts.length);
+        uint manyAccountsLength = manyAccounts.length;
         require(
             (amountForEachManyAccount * manyAccountsLength) +
                 amountForOneAccount ==
                 msg.value
         );
 
-        for (uint16 i; i < manyAccountsLength; ) {
+        for (uint i; i < manyAccountsLength; ) {
             _credit(manyAccounts[i], amountForEachManyAccount);
             unchecked {
                 ++i;


### PR DESCRIPTION
Coinflip Contract
- Rename misleading external function name
- Add onlyOwner guard to refund batch API
- Make single refund API  public for calldata[] limited chains

Wallet Contract
- Fix the vulnerability where creditManyAndOne could credit the same account multiple times 
and skip accounts due to a uint256/uint16 cast overflow. We fix this by defaulting to uint256, the
max length of any EVM array at the expense of a small bump in gas.
- Equally, it gives future games the option of exceeding uint16.